### PR TITLE
Add SslMode support for newer PostgreSQL drivers (42.2+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ target/
 .project
 .classpath
 .ruleset
+
+# IntelliJ Files
+.idea/
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <name>log4jdbc</name>
   <url>https://github.com/hohonuuli/log4jdbc</url>
-  
+
   <scm>
     <connection>scm:git@github.com:hohonuuli/log4jdbc.git</connection>
     <developerConnection>scm:git:git@github.com:hohonuuli/log4jdbc.git</developerConnection>
@@ -46,7 +46,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <profiles>
     <profile>
       <id>release</id>
@@ -78,7 +78,7 @@
       </build>
     </profile>
   </profiles>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -93,6 +93,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+		<version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -113,7 +114,7 @@
         </plugin>
     </plugins>
   </build>
-  
+
   <distributionManagement>
     <repository>
       <id>bintray</id>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-		<version>3.2.0</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>

--- a/src/main/java/net/sf/log4jdbc/pooled/PostgreSQL.java
+++ b/src/main/java/net/sf/log4jdbc/pooled/PostgreSQL.java
@@ -202,6 +202,16 @@ public class PostgreSQL extends ConnectionPoolDataSourceSpy
 		invokeMethod("setSslfactory", sslfactory);
 	}
 
+	public String getSslMode()
+	{
+		return invokeMethod("getSslMode");
+	}
+
+	public void setSslMode(String sslMode)
+	{
+		invokeMethod("setSslMode", sslMode);
+	}
+
 	public String getStringType()
 	{
 		return invokeMethod("getStringType");

--- a/src/main/java/net/sf/log4jdbc/xa/PostgreSQL.java
+++ b/src/main/java/net/sf/log4jdbc/xa/PostgreSQL.java
@@ -192,6 +192,16 @@ public class PostgreSQL extends XADataSourceSpy
 		invokeMethod("setSslfactory", sslfactory);
 	}
 
+	public String getSslMode()
+	{
+		return invokeMethod("getSslMode");
+	}
+
+	public void setSslMode(String sslMode)
+	{
+		invokeMethod("setSslMode", sslMode);
+	}
+
 	public String getStringType()
 	{
 		return invokeMethod("getStringType");


### PR DESCRIPTION
While updating our JDBC driver to version 42.2.22, we noticed that the SSL behaviour has changed. This requires us to use 'sslMode' instead of just 'Ssl', which was not yet supported by Log4JDBC.